### PR TITLE
most versions of the find command need a starting path

### DIFF
--- a/kernel-builder.sh
+++ b/kernel-builder.sh
@@ -315,7 +315,7 @@ fi
 # copy over old config?
 if [[ "$LASTCONFIG" = "y" ]]; then
   # find most recent build config
-  LASTBUILDCONF=$(find -type f -name build.config -exec ls {} -t \; 2>/dev/null| grep build_ | tail -n1)
+  LASTBUILDCONF=$(find . -type f -name build.config -exec ls {} -t \; 2>/dev/null| grep build_ | tail -n1)
   if [ -z $LASTBUILDCONF ]; then
     echo "No previous config found"
     exit 1


### PR DESCRIPTION
the find command normally requires, or at least expects, a starting path.  Better to be explicit about where we want to look.
